### PR TITLE
Fix intermediate/root selection logic bug

### DIFF
--- a/src/main/java/com/floragunn/searchguard/tools/tlstool/tasks/LoadCa.java
+++ b/src/main/java/com/floragunn/searchguard/tools/tlstool/tasks/LoadCa.java
@@ -44,11 +44,11 @@ public class LoadCa extends Task {
 		if (caConfig.getIntermediate() != null) {
 			this.signingCertificateConfig = caConfig.getIntermediate();
 			this.fileNameBase = "signing-ca";
-			ctx.setRootCaFile(getConfiguredFile(caConfig.getRoot().getFile(), "root-ca.pem", "pem"));
+			ctx.setRootCaFile(getConfiguredFile(caConfig.getIntermediate().getFile(), "signing-ca.pem", "pem"));
 		} else {
 			this.signingCertificateConfig = caConfig.getRoot();
 			this.fileNameBase = "root-ca";
-			ctx.setRootCaFile(getConfiguredFile(caConfig.getIntermediate().getFile(), "signing-ca.pem", "pem"));
+			ctx.setRootCaFile(getConfiguredFile(caConfig.getRoot().getFile(), "root-ca.pem", "pem"));
 		}
 
 		if (this.signingCertificateConfig == null) {


### PR DESCRIPTION
Because the `getIntermediate` and `getRoot` calls can return `null` this
leads to a NullPointerException.